### PR TITLE
CI update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,23 +34,23 @@ jobs:
 
     # per https://github.com/tuist/tuist/discussions/2802, we could also
     # bundle and include tuist in tthe repository if that had value.
-    # - name: Install Tuist
-    #   run: curl -Ls https://install.tuist.io | bash
+    - name: Install Tuist
+      run: curl -Ls https://install.tuist.io | bash
 
-    # - name: Tuist Fetch
-    #   run: |
-    #     cd examples
-    #     tuist fetch
+    - name: Tuist Fetch
+      run: |
+        cd examples
+        tuist fetch
 
-    # - name: Tuist Generate
-    #   run: |
-    #     cd examples
-    #     tuist generate -n
+    - name: Tuist Generate
+      run: |
+        cd examples
+        tuist generate -n
 
-    # - name: Tuist Test
-    #   run: |
-    #     cd examples
-    #     tuist test YSwift
+    - name: Tuist Test
+      run: |
+        cd examples
+        tuist build
 
     # NOTE: use `xcodebuild -list` to show the local schemes available
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ jobs:
   build:
 
     runs-on: macos-12 #macOS Monterey
+    env:
+      YSWIFT_LOCAL: true
 
     steps:
     - name: Checkout Project
@@ -37,17 +39,17 @@ jobs:
 
     # - name: Tuist Fetch
     #   run: |
-    #     cd yswift
+    #     cd examples
     #     tuist fetch
 
     # - name: Tuist Generate
     #   run: |
-    #     cd yswift
+    #     cd examples
     #     tuist generate -n
 
     # - name: Tuist Test
     #   run: |
-    #     cd yswift
+    #     cd examples
     #     tuist test YSwift
 
     # NOTE: use `xcodebuild -list` to show the local schemes available
@@ -65,7 +67,7 @@ jobs:
     #run: xcodebuild clean build -scheme YSwift -destination 'platform=iOS Simulator,OS=15.5,name=iPhone 8' -showBuildTimingSummary
 
     #- name: check against API breaking changes
-    #  run: swift package diagnose-api-breaking-changes 0.5.0
+    #  run: swift package diagnose-api-breaking-changes 0.1.0
 
     # - name: Prepare Code Coverage
     #   run: xcrun llvm-cov export -format="lcov" .build/debug/xxx.xctest/Contents/MacOS/xx -instr-profile .build/debug/codecov/default.profdata > info.lcov

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.DS_Store
 .swiftpm
+Package.resolved
 
 *.xcodeproj
 Derived/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing to YSwift
+
+This project is a Swift language layer over a binding to the Rust [Yrs](https://github.com/y-crdt/y-crdt) library using Mozilla's [UniFFI](https://github.com/mozilla/uniffi-rs/) project.
+
+## Issues and project work
+
+Issues for `YSwift` are tracked on GitHub at https://github.com/y-crdt/yswift/issues.
+We typically keep our roadmap plans within one of those issues, and use issues to loosely track out progress.
+
+This project keeps track of decision points and choices in the library development in a [Developer's Log](./devnotes/DevLog.md), and has a [release process documented](./devnotes/release-process.md).
+
+## Local Development Setup
+
+Scripts in the project build an XCFramework for iOS and macOS using UniFFI from the Rust sources as defined in [lib/Cargo.toml](./lib/Cargo.toml).
+The binary included in the released XCFramework is intimately tied to the code that UniFFI generates into `lib/swift/scaffold`.
+
+The rough pattern of dependencies that are reflected in `Package.swift`:
+
+```
+   +-----------+      +--------+      +--------+
+   | yniffiFFI | <--- | Yniffi | <--- | YSwift |
+   +-----------+      +--------+      +--------+
+ C static library       UniFFI      Developer created
+  from Rust lib        generated      Swift overlay
+```
+
+If you are working on any of the layers within the `lib` directory (the targets `yniffiFFI` or `Yniffi`) then set a local environment variable `LOCALDEV` to true and regenerate the XCFramework using the script `scripts/build-xcframework.sh`.
+The [Package.swift](./Package.swift) file is configured to look for the `LOCALDEV` environment variable and use a local reference to the XCFramework if it is set.
+Without that environment variable set, `Package.swift` uses the latest release version of the XCFramework.
+
+If you are working on the Swift overlay (`YSwift` target), then you can safely use
+the previous released version of the XCFramework and its associated generated code for `Yniffi`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,22 @@ The rough pattern of dependencies that are reflected in `Package.swift`:
   from Rust lib        generated      Swift overlay
 ```
 
-If you are working on any of the layers within the `lib` directory (the targets `yniffiFFI` or `Yniffi`) then set a local environment variable `LOCALDEV` to true and regenerate the XCFramework using the script `scripts/build-xcframework.sh`.
-The [Package.swift](./Package.swift) file is configured to look for the `LOCALDEV` environment variable and use a local reference to the XCFramework if it is set.
+If you are working on any of the layers within the `lib` directory (the targets `yniffiFFI` or `Yniffi`) then set a local environment variable `YSWIFT_LOCAL` to true and regenerate the XCFramework using the script `scripts/build-xcframework.sh`.
+The script to build the XCFramework file expects that you have Rust installed locally.
+For example, from the roof of the repository:
+
+```bash
+export YSWIFT_LOCAL=true
+`scripts/build-xcframework.sh`
+```
+
+To go back to using the latest released XCFramework, unset the environment variable `YSWIFT_LOCAL`:
+
+```bash
+unset YSWIFT_LOCAL
+```
+
+The [Package.swift](./Package.swift) file is configured to look for the `YSWIFT_LOCAL` environment variable and use a local reference to the XCFramework if it is set.
 Without that environment variable set, `Package.swift` uses the latest release version of the XCFramework.
 
 If you are working on the Swift overlay (`YSwift` target), then you can safely use

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 var globalSwiftSettings: [PackageDescription.SwiftSetting] = []
 #if swift(>=5.7)
-    globalSwiftSettings.append(.unsafeFlags(["-Xfrontend", "-strict-concurrency=complete"]))
+    //globalSwiftSettings.append(.unsafeFlags(["-Xfrontend", "-strict-concurrency=complete"]))
     /*
      Summation from https://www.donnywals.com/enabling-concurrency-warnings-in-xcode-14/
      Set `strict-concurrency` to `targeted` to enforce Sendable and actor-isolation
@@ -43,9 +43,13 @@ let package = Package(
         // If you're working from source, or a branch without an existing xcframework.zip,
         // use the script `./scripts/build-xcframework.sh` to create the library locally.
         // This script _does_ expect that you have Rust installed locally in order to function.
+
         .binaryTarget(
             name: "yniffiFFI",
-            path: "./lib/yniffiFFI.xcframework"
+            // Uncomment `path`, and comment out url and checksum, for local development
+            // path: "./lib/yniffiFFI.xcframework"
+            url: "https://github.com/y-crdt/yswift/releases/download/0.1.0/yniffiFFI.xcframework.zip",
+            checksum: "4bba5754a02eec941591dc32efe65692031565371dc0db3cfcf64438d96e5b6c"
         ),
         .target(
             name: "Yniffi",

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ var globalSwiftSettings: [PackageDescription.SwiftSetting] = []
 // Only enable if Swift 5.7+ is available and the environment variable `LOCALDEV` is
 // set to a value (such as 'true')
 #if swift(>=5.7)
-    if ProcessInfo.processInfo.environment["LOCALDEV"] != nil {
+    if ProcessInfo.processInfo.environment["YSWIFT_LOCAL"] != nil {
         /*
         Summation from https://www.donnywals.com/enabling-concurrency-warnings-in-xcode-14/
         Set `strict-concurrency` to `targeted` to enforce Sendable and actor-isolation
@@ -28,12 +28,13 @@ var globalSwiftSettings: [PackageDescription.SwiftSetting] = []
 #endif
 
 let FFIbinaryTarget: PackageDescription.Target
-// If either of the environment variables `CI` or `LOCALDEV` are set, then use
+// If either the environment variable `YSWIFT_LOCAL` is set to any value, the packages uses
 // a local reference to an XCFramework file (built from `./scripts/build-xcframework.sh`)
-// instead of the previous released version.
+// rather than the previous released version.
 //
-// This script _does_ expect that you have Rust installed locally in order to function.
-if ProcessInfo.processInfo.environment["CI"] != nil || ProcessInfo.processInfo.environment["LOCALDEV"] != nil {
+// The script `./scripts/build-xcframework.sh` _does_ expect that you have Rust 
+// installed locally in order to function.
+if ProcessInfo.processInfo.environment["YSWIFT_LOCAL"] != nil {
     // We are using a local file reference to an XCFramework, which is functional
     // on the tags for this package because the XCFramework.zip file is committed with
     // those specific release points. This does, however, cause a few awkward issues,

--- a/Package.swift
+++ b/Package.swift
@@ -1,25 +1,58 @@
 // swift-tools-version:5.6
 
 import PackageDescription
+import Foundation
 
 var globalSwiftSettings: [PackageDescription.SwiftSetting] = []
+
+// Only enable if Swift 5.7+ is available and the environment variable `LOCALDEV` is
+// set to a value (such as 'true')
 #if swift(>=5.7)
-    //globalSwiftSettings.append(.unsafeFlags(["-Xfrontend", "-strict-concurrency=complete"]))
-    /*
-     Summation from https://www.donnywals.com/enabling-concurrency-warnings-in-xcode-14/
-     Set `strict-concurrency` to `targeted` to enforce Sendable and actor-isolation
-     checks in your code. This explicitly verifies that `Sendable` constraints are
-     met when you mark one of your types as `Sendable`.
+    if ProcessInfo.processInfo.environment["LOCALDEV"] != nil {
+        /*
+        Summation from https://www.donnywals.com/enabling-concurrency-warnings-in-xcode-14/
+        Set `strict-concurrency` to `targeted` to enforce Sendable and actor-isolation
+        checks in your code. This explicitly verifies that `Sendable` constraints are
+        met when you mark one of your types as `Sendable`.
 
-     This mode is essentially a bit of a hybrid between the behavior that's intended
-     in Swift 6, and the default in Swift 5.7. Use this mode to have a bit of
-     checking on your code that uses Swift concurrency without too many warnings
-     and / or errors in your current codebase.
+        This mode is essentially a bit of a hybrid between the behavior that's intended
+        in Swift 6, and the default in Swift 5.7. Use this mode to have a bit of
+        checking on your code that uses Swift concurrency without too many warnings
+        and / or errors in your current codebase.
 
-     Set `strict-concurrency` to `complete` to get the full suite of concurrency
-     constraints, essentially as they will work in Swift 6.
-     */
+        Set `strict-concurrency` to `complete` to get the full suite of concurrency
+        constraints, essentially as they will work in Swift 6.
+        */
+        globalSwiftSettings.append(.unsafeFlags(["-Xfrontend", "-strict-concurrency=complete"]))
+    }
 #endif
+
+let FFIbinaryTarget: PackageDescription.Target
+// If either of the environment variables `CI` or `LOCALDEV` are set, then use
+// a local reference to an XCFramework file (built from `./scripts/build-xcframework.sh`)
+// instead of the previous released version.
+//
+// This script _does_ expect that you have Rust installed locally in order to function.
+if ProcessInfo.processInfo.environment["CI"] != nil || ProcessInfo.processInfo.environment["LOCALDEV"] != nil {
+    // We are using a local file reference to an XCFramework, which is functional
+    // on the tags for this package because the XCFramework.zip file is committed with
+    // those specific release points. This does, however, cause a few awkward issues,
+    // in particular it means that swift-docc-plugin doesn't operate correctly as the
+    // process to retrieve the symbols from this and the XCFramework fails within
+    // Swift Package Manager. Building documentation within Xcode works perfectly fine,
+    // but if you're attempting to generate HTML documentation, use the script
+    // `./scripts/build-ghpages-docs.sh`.
+    FFIbinaryTarget = .binaryTarget(
+            name: "yniffiFFI",
+            path: "./lib/yniffiFFI.xcframework"
+    )
+} else {
+    FFIbinaryTarget = .binaryTarget(
+            name: "yniffiFFI",
+            url: "https://github.com/y-crdt/yswift/releases/download/0.1.0/yniffiFFI.xcframework.zip",
+            checksum: "4bba5754a02eec941591dc32efe65692031565371dc0db3cfcf64438d96e5b6c"
+    )
+}
 
 let package = Package(
     name: "YSwift",
@@ -31,26 +64,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.1.0"),
     ],
     targets: [
-        // We are using a local file reference to an XCFramework, which is functional
-        // on the tags for this package because the XCFramework.zip file is committed with
-        // those specific release points. This does, however, cause a few awkward issues,
-        // in particular it means that swift-docc-plugin doesn't operate correctly as the
-        // process to retrieve the symbols from this and the XCFramework fails within
-        // Swift Package Manager. Building documentation within Xcode works perfectly fine,
-        // but if you're attempting to generate HTML documentation, use the script
-        // `./scripts/build-ghpages-docs.sh`.
-        //
-        // If you're working from source, or a branch without an existing xcframework.zip,
-        // use the script `./scripts/build-xcframework.sh` to create the library locally.
-        // This script _does_ expect that you have Rust installed locally in order to function.
-
-        .binaryTarget(
-            name: "yniffiFFI",
-            // Uncomment `path`, and comment out url and checksum, for local development
-            // path: "./lib/yniffiFFI.xcframework"
-            url: "https://github.com/y-crdt/yswift/releases/download/0.1.0/yniffiFFI.xcframework.zip",
-            checksum: "4bba5754a02eec941591dc32efe65692031565371dc0db3cfcf64438d96e5b6c"
-        ),
+        FFIbinaryTarget,
         .target(
             name: "Yniffi",
             dependencies: ["yniffiFFI"],

--- a/devnotes/release-process.md
+++ b/devnotes/release-process.md
@@ -41,25 +41,16 @@ The pattern is roughly:
 https://github.com/heckj/yswift/releases/download/0.1.0/yniffiFFI.xcframework.zip
 ```
 
+- Set the checksum to the one you just captured for the build of the XCFramework.
+
 The end result of that section of Package.swift should look something like:
 
-```
-        .binaryTarget(
-            name: "yniffiFFI",
-            // Uncomment `path`, and comment out url and checksum, for local development
-            // path: "./lib/yniffiFFI.xcframework"
-            url: "https://github.com/y-crdt/yswift/releases/download/0.1.0/yniffiFFI.xcframework.zip",
-            checksum: "9aa2dd069662613b66749a257d753fc7007afe4817278edfd6cc902de94b5f6c"
-        ),
-```
-
-- Set the checksum to the one you just captured for the build of the XCFramework.
-- Comment out the globalSwiftSettings that sets unsafe build flags. An external Xcode project won't allow using this package when it has "unsafe flags" defined on it.
-
-```
-var globalSwiftSettings: [PackageDescription.SwiftSetting] = []
-#if swift(>=5.7)
-    //globalSwiftSettings.append(.unsafeFlags(["-Xfrontend", "-strict-concurrency=complete"]))
+```swift
+  FFIbinaryTarget = .binaryTarget(
+          name: "yniffiFFI",
+          url: "https://github.com/y-crdt/yswift/releases/download/0.1.0/yniffiFFI.xcframework.zip",
+          checksum: "4bba5754a02eec941591dc32efe65692031565371dc0db3cfcf64438d96e5b6c"
+  )
 ```
 
 (Note: at this stage, a local build will not work - as we haven't created the release yet on GitHub with its artifacts)

--- a/examples/Project.swift
+++ b/examples/Project.swift
@@ -1,12 +1,5 @@
 import ProjectDescription
 
-let dependencies = Dependencies(
-    swiftPackageManager: [
-        .local(path: ".."),
-    ],
-    platforms: [.iOS]
-)
-
 let exampleTodolist = Target(
     name: "TodoListExample",
     platform: .iOS,
@@ -19,7 +12,9 @@ let exampleTodolist = Target(
     ]),
     sources: ["Examples/Todolist/**"],
     resources: ["Examples/Todolist/LaunchScreen.storyboard"],
-    dependencies: [.external(name: "YSwift")]
+    dependencies: [
+      .external(name: "YSwift"),
+    ]
 )
 
 let project = Project(

--- a/examples/Tuist/Dependencies.swift
+++ b/examples/Tuist/Dependencies.swift
@@ -2,7 +2,7 @@ import ProjectDescription
 
 let dependencies = Dependencies(
     swiftPackageManager: [
-        .local(path: "../"),
+        .remote(url: "https://github.com/y-crdt/yswift", requirement: .upToNextMajor(from: "0.1.0")),
     ],
     platforms: [.iOS]
 )


### PR DESCRIPTION
The "comment this out, change that" process from the release seemed too easy to make a mistake, so I took a bit of time and updated Package.swift to select choices based on having environment variables set.

The gist being that if we want to work on the Rust layer or C-level interface through UniFFI, we should continued to build the local XCFramework and set an environment variable `LOCALDEV` to use it. By default, without that set, the Package.swift will use the latest released version, and assumes that the code in `lib/swift/scaffold` hasn't been regenerated.

Happy to choose an alternate environment variable if y'all prefer, I just "picked one" that seemed reasonable. I've also set it up so that the CI system will _always_ build the XCFramework locally for the purposes of testing, just to make sure we don't accidentally regress something and not catch it locally.

I also took the time to document this detail in a new CONTRIBUTING.md file, which looked to be a rough standard for where to find project-specific contributing details.